### PR TITLE
[WIP] [coverage] apply line/column offsets calculating positions

### DIFF
--- a/src/objects.cc
+++ b/src/objects.cc
@@ -11206,11 +11206,24 @@ static void CalculateLineEndsImpl(Isolate* isolate, std::vector<int>* line_ends,
 
 Handle<FixedArray> String::CalculateLineEnds(Handle<String> src,
                                              bool include_ending_line) {
+  Isolate* isolate = src->GetIsolate();
+  std::vector<int> line_ends =
+      String::GetLineEndsVector(src, include_ending_line);
+  int line_count = static_cast<int>(line_ends.size());
+  Handle<FixedArray> array = isolate->factory()->NewFixedArray(line_count);
+  for (int i = 0; i < line_count; i++) {
+    array->set(i, Smi::FromInt(line_ends[i]));
+  }
+  return array;
+}
+
+std::vector<int> String::GetLineEndsVector(Handle<String> src,
+                                           bool include_ending_line) {
+  std::vector<int> line_ends;
   src = Flatten(src);
   // Rough estimate of line count based on a roughly estimated average
   // length of (unpacked) code.
   int line_count_estimate = src->length() >> 4;
-  std::vector<int> line_ends;
   line_ends.reserve(line_count_estimate);
   Isolate* isolate = src->GetIsolate();
   { DisallowHeapAllocation no_allocation;  // ensure vectors stay valid.
@@ -11229,12 +11242,7 @@ Handle<FixedArray> String::CalculateLineEnds(Handle<String> src,
                             include_ending_line);
     }
   }
-  int line_count = static_cast<int>(line_ends.size());
-  Handle<FixedArray> array = isolate->factory()->NewFixedArray(line_count);
-  for (int i = 0; i < line_count; i++) {
-    array->set(i, Smi::FromInt(line_ends[i]));
-  }
-  return array;
+  return line_ends;
 }
 
 

--- a/src/objects/string.h
+++ b/src/objects/string.h
@@ -437,6 +437,9 @@ class String : public Name {
   static Handle<FixedArray> CalculateLineEnds(Handle<String> string,
                                               bool include_ending_line);
 
+  static std::vector<int> GetLineEndsVector(Handle<String> src,
+                                            bool include_ending_line);
+
  private:
   friend class Name;
   friend class StringTableInsertionKey;

--- a/test/inspector/cpu-profiler/coverage-block-expected.txt
+++ b/test/inspector/cpu-profiler/coverage-block-expected.txt
@@ -1110,3 +1110,66 @@ Running test: testPreciseCountCoveragePartial
         ]
     }
 }
+
+Running test: testCoverageLineOffset
+{
+    id : <messageId>
+    result : {
+        result : [
+            [0] : {
+                functions : [
+                    [0] : {
+                        functionName :
+                        isBlockCoverage : true
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 297
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                    [1] : {
+                        functionName :
+                        isBlockCoverage : true
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 249
+                                startOffset : 0
+                            }
+                            [1] : {
+                                count : 0
+                                endOffset : 180
+                                startOffset : 172
+                            }
+                            [2] : {
+                                count : 0
+                                endOffset : 248
+                                startOffset : 209
+                            }
+                        ]
+                    }
+                    [2] : {
+                        functionName : a
+                        isBlockCoverage : true
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 99
+                                startOffset : 0
+                            }
+                            [1] : {
+                                count : 0
+                                endOffset : 88
+                                startOffset : 77
+                            }
+                        ]
+                    }
+                ]
+                scriptId : <scriptId>
+                url : testCoverageLineOffset
+            }
+        ]
+    }
+}

--- a/test/inspector/cpu-profiler/coverage-block.js
+++ b/test/inspector/cpu-profiler/coverage-block.js
@@ -50,6 +50,16 @@ var f = (function outer() {
 f()()();
 `;
 
+var line_offset =
+`(function (foo) {                         // 0000
+const bar = 99                            // 0050
+  function a () {                         // 0100
+    const a = true ? 'hello' : 'goodbye'; // 0150
+}                                         // 0200
+const x = true ? 'cool' : 'neat';         // 0250
+return a();                               // 0300
+})(99);                                   // 0350`
+
 let {session, contextGroup, Protocol} = InspectorTest.start("Test collecting code coverage data with Profiler.collectCoverage.");
 
 function ClearAndGC() {
@@ -286,4 +296,18 @@ InspectorTest.runTestSuite([
       .then(ClearAndGC)
       .then(next);
   },
+  function testCoverageLineOffset(next)
+  {
+    Protocol.Runtime.enable()
+      .then(Protocol.Profiler.enable)
+      .then(() => Protocol.Profiler.startPreciseCoverage({callCount: true, detailed: true}))
+      .then(() => utils.compileAndRunWithOrigin(contextGroup.id, line_offset, arguments.callee.name, 2, 3, false))
+      .then(Protocol.Profiler.takePreciseCoverage)
+      .then(LogSorted)
+      .then(Protocol.Profiler.stopPreciseCoverage)
+      .then(Protocol.Profiler.disable)
+      .then(Protocol.Runtime.disable)
+      .then(ClearAndGC)
+      .then(next);
+  }
 ]);

--- a/test/inspector/cpu-profiler/coverage-expected.txt
+++ b/test/inspector/cpu-profiler/coverage-expected.txt
@@ -823,3 +823,99 @@ Running test: testPreciseCountCoveragePartial
         ]
     }
 }
+
+Running test: testCoverageColumnOffset
+{
+    id : <messageId>
+    result : {
+        result : [
+            [0] : {
+                functions : [
+                    [0] : {
+                        functionName :
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 49
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                    [1] : {
+                        functionName :
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 43
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                    [2] : {
+                        functionName : a
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 2
+                                endOffset : 31
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                ]
+                scriptId : <scriptId>
+                url : testCoverageColumnOffset
+            }
+        ]
+    }
+}
+
+Running test: testCoverageLineOffset
+{
+    id : <messageId>
+    result : {
+        result : [
+            [0] : {
+                functions : [
+                    [0] : {
+                        functionName :
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 247
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                    [1] : {
+                        functionName :
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 199
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                    [2] : {
+                        functionName : a
+                        isBlockCoverage : false
+                        ranges : [
+                            [0] : {
+                                count : 1
+                                endOffset : 99
+                                startOffset : 0
+                            }
+                        ]
+                    }
+                ]
+                scriptId : <scriptId>
+                url : testCoverageLineOffset
+            }
+        ]
+    }
+}


### PR DESCRIPTION
line and column positions specified when running script through API will now
be taken into account when remapping coverage. Some caveats: ranges less than
0 will be pinned to 0; the characters appended to the end of a script wrapped
in a function are not taken into account (when calculating max offset).

Bug: v8:7119